### PR TITLE
Fix memory overlap bug

### DIFF
--- a/examples/person_detection/main/main_functions.cc
+++ b/examples/person_detection/main/main_functions.cc
@@ -95,7 +95,7 @@ void setup() {
   micro_op_resolver.AddPadV2();
   micro_op_resolver.AddAdd();
   micro_op_resolver.AddAddN();
-  micro_op_resolver.AddFullyConnected();  
+  micro_op_resolver.AddFullyConnected();
 
   // Build an interpreter to run the model with.
   // NOLINTNEXTLINE(runtime-global-variables)


### PR DESCRIPTION
It is observed that tflite micro erroneously uses same memory pointer for output as that of a scratch buffer leading to corruption.

Fixed this for now by allocating scratch buffer dynamically.
